### PR TITLE
GraphQL Http client

### DIFF
--- a/graphql_client/GraphQLHttpClient.py
+++ b/graphql_client/GraphQLHttpClient.py
@@ -9,3 +9,6 @@ class GraphQLHttpClient:
         payload = { 'headers': headers, 'query' : query, 'variables': variables }
         resp = requests.post(self.http_url, json=payload)
         return resp
+
+    def mutation(self, query, variables=None, headers=None):
+        return self.query(query, variables, headers)

--- a/graphql_client/GraphQLHttpClient.py
+++ b/graphql_client/GraphQLHttpClient.py
@@ -1,0 +1,11 @@
+import requests
+
+class GraphQLHttpClient:
+
+    def __init__(self, url):
+        self.http_url = url
+
+    def query(self, query, variables=None, headers=None):
+        payload = { 'headers': headers, 'query' : query, 'variables': variables }
+        resp = requests.post(self.http_url, json=payload)
+        return resp

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -45,10 +45,13 @@ class GraphQLClient():
         self._conn.send(json.dumps(payload))
         self._conn.recv()
 
+
     def _start(self, payload):
         _id = gen_id()
         frame = {'id': _id, 'type': 'start', 'payload': payload}
         self._conn.send(json.dumps(frame))
+        # commenting this as the spec excepts data after start and subscription misses the first data if data is received here
+        # res = self._conn.recv()
         return _id
 
     def _stop(self, _id):

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -45,11 +45,13 @@ class GraphQLClient():
         self._conn.send(json.dumps(payload))
         self._conn.recv()
 
+
     def _start(self, payload):
         _id = gen_id()
         frame = {'id': _id, 'type': 'start', 'payload': payload}
         self._conn.send(json.dumps(frame))
-        self._conn.recv()
+        # commenting this as the spec excepts data after start and subscription misses the first data if data is received here
+        # res = self._conn.recv()
         return _id
 
     def _stop(self, _id):
@@ -61,8 +63,8 @@ class GraphQLClient():
         self._conn_init(headers)
         payload = {'headers': headers, 'query': query, 'variables': variables}
         _id = self._start(payload)
-        self._conn.recv()
-        res = self._stop(_id)
+        res = self._conn.recv()
+        self._stop(_id)
         #print(dir(self._conn))
         return res
 

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -45,13 +45,10 @@ class GraphQLClient():
         self._conn.send(json.dumps(payload))
         self._conn.recv()
 
-
     def _start(self, payload):
         _id = gen_id()
         frame = {'id': _id, 'type': 'start', 'payload': payload}
         self._conn.send(json.dumps(frame))
-        # commenting this as the spec excepts data after start and subscription misses the first data if data is received here
-        # res = self._conn.recv()
         return _id
 
     def _stop(self, _id):


### PR DESCRIPTION
A Basic Http Client to support Query and Mutations over http.

Sample Query Usage:
```
from  graphql_client import GraphQLHttpClient

httpClient = GraphQLHttpClient.GraphQLHttpClient("http://localhost:8080/graphql")
q = """
  query ($limit: Int!) {
    notifications (order_by: {created: "desc"}, limit: $limit) {
      id
      title
      content
    }
  }
"""
response = httpClient.query(query=q, variables={'limit': 10})
print(response.text)
```
Even the mutation works the same way. It internally calls query itself.

```
from  graphql_client import GraphQLHttpClient
httpClient = GraphQLHttpClient.GraphQLHttpClient("http://localhost:8080/graphql")
mutation = """
  mutation{
    uploadData(file:"xxx/somefilepath.txt"){
    id
  }
}
"""
response = httpClient.mutation(query=mutation)
```
