### PR TITLE
add graphql-ws as sub-protocol while connecting (fix #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,5 +123,8 @@ dmypy.json
 ### Python Patch ###
 .venv/
 
+# Editor configs
+.vcode/
+
 # End of https://www.gitignore.io/api/python
 ws/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+# [Unreleased]
+## Fixed
+- Connecting via WSS should now work
+
 # 0.1.0
 - basic working of GraphQL over Websocket (Apollo) protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased]
 ## Fixed
-- Connecting via WSS should now work
+- Added `graphql-ws` subprotocol header to help with some WSS connections
 
 # 0.1.0
 - basic working of GraphQL over Websocket (Apollo) protocol

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ ws.close()
 
 
 ## TODO
-- currently wss doesn't not work. support wss.
 - tests
 - support http as well
 - should use asyncio websocket library?

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -15,6 +15,9 @@ import threading
 import websocket
 
 
+WSS_HEADER = "Sec-WebSocket-Protocol: graphql-ws"
+
+
 class GraphQLClient():
     """
     A simple GraphQL client that works over Websocket as the transport
@@ -25,8 +28,10 @@ class GraphQLClient():
 
     def __init__(self, url):
         self.ws_url = url
+
         self._conn = websocket.create_connection(self.ws_url,
-                                                 on_message=self._on_message)
+                                                 on_message=self._on_message,
+                                                 header=[WSS_HEADER])
         self._conn.on_message = self._on_message
         self._subscription_running = False
         self._st_id = None

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -15,7 +15,7 @@ import threading
 import websocket
 
 
-WSS_HEADER = "Sec-WebSocket-Protocol: graphql-ws"
+GQL_SUBPROTOCOL_HEADER = "Sec-WebSocket-Protocol: graphql-ws"
 
 
 class GraphQLClient():
@@ -31,7 +31,7 @@ class GraphQLClient():
 
         self._conn = websocket.create_connection(self.ws_url,
                                                  on_message=self._on_message,
-                                                 header=[WSS_HEADER])
+                                                 header=[GQL_SUBPROTOCOL_HEADER])
         self._conn.on_message = self._on_message
         self._subscription_running = False
         self._st_id = None

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -15,7 +15,7 @@ import threading
 import websocket
 
 
-GQL_SUBPROTOCOL_HEADER = "Sec-WebSocket-Protocol: graphql-ws"
+GQL_WS_SUBPROTOCOL = "graphql-ws"
 
 
 class GraphQLClient():
@@ -28,10 +28,9 @@ class GraphQLClient():
 
     def __init__(self, url):
         self.ws_url = url
-
         self._conn = websocket.create_connection(self.ws_url,
                                                  on_message=self._on_message,
-                                                 header=[GQL_SUBPROTOCOL_HEADER])
+                                                 subprotocols=[GQL_WS_SUBPROTOCOL])
         self._conn.on_message = self._on_message
         self._subscription_running = False
         self._st_id = None
@@ -49,7 +48,6 @@ class GraphQLClient():
         }
         self._conn.send(json.dumps(payload))
         self._conn.recv()
-
 
     def _start(self, payload):
         _id = gen_id()


### PR DESCRIPTION
Closes #1 

Now passes the `"Sec-WebSocket-Protocol: graphql-ws"` in the initial connection, which should fix connecting over the `WSS://` protocol for some servers.

I also updated the changelog and readme files to reflect this