### PR TITLE
Removing sleep.  The conn.recv call is blocking

### DIFF
--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -9,7 +9,6 @@ https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL
 import string
 import random
 import json
-import time
 import threading
 
 import websocket
@@ -83,7 +82,6 @@ class GraphQLClient():
                     break
                 elif r['type'] != 'ka':
                     _cc(_id, r)
-                time.sleep(1)
 
         self._st_id = threading.Thread(target=subs, args=(_cc,))
         self._st_id.start()


### PR DESCRIPTION
This is purely a suggestion.  The time.sleep isn't really needed here since we're gonna wait on the conn.recv call anyway.  If subscription messages come in faster than 1 second, the connection is gonna back up w/ requests and the server may eventually timeout on sends.

I've tested this on my own project and it speeds up subscriptions quite a bit.  You can confirm this works by subscribing to something and then watching "top" to make sure your process isn't looping and chewing up CPU time.
