### PR TITLE
add support for context manager API (fix #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
-# [Unreleased]
-## Fixed
+# Unreleased
+
+## Fixes
+
+## Enhancements/Features
+- Added support for context manager API
+  now you can use the client with context manager API, like so:
+  ```python
+  with GraphQLClient("ws://localhost/graphql") as client:
+      client.subscribe(...)
+  ```
+
+
+# 0.1.1
+
+## Fixes
+- fixed: when stop_subscribe was called it would stop the receive thread, so further subscription would not work
+- fixed: if more than operations were scheduled, the correct callback might not receive the correct data
+- refactor: use a separate thread all the time to continously receive data from the server and put it on queues
+- refactor: use separate queues for each operation to properly keep track of incoming and data and who it is meant for
+- other misc improvements
+- Removing sleep, the `conn.recv` call is blocking
 - Added `graphql-ws` subprotocol header to help with some WSS connections
+
+## Enhancements/Features
+- UUIDv4 for generating operation IDs (#16)
+- Added tests
+
 
 # 0.1.0
 - basic working of GraphQL over Websocket (Apollo) protocol

--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -237,3 +237,11 @@ class GraphQLClient():
         self._shutdown_receiver = True
         self._connection.close()
         self._recevier_thread.join()
+
+    def __enter__(self):
+        """ enter method for context manager """
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """ exit method for context manager """
+        self.close()


### PR DESCRIPTION
Now you can use the client with context manager API, like so:

```python
with GraphQLClient("ws://localhost/graphql") as client:
    client.subscribe(...)
```

Closes #21 