### PR TITLE
Fixed GraphQLClient.close() method

### DIFF
--- a/graphql_client/__init__.py
+++ b/graphql_client/__init__.py
@@ -235,8 +235,8 @@ class GraphQLClient():
         method.
         """
         self._shutdown_receiver = True
-        self._connection.close()
         self._recevier_thread.join()
+        self._connection.close()
 
     def __enter__(self):
         """ enter method for context manager """


### PR DESCRIPTION
The proper order is:
1. flag receiver to shutdown
2. what for receiver thread exited
3. close connection

Without it it's possible to face with an attempt to read from closed socket:

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/remy/.local/lib/python3.6/site-packages/graphql_client/__init__.py", line 85, in _receiver_task
    res = self._connection.recv()
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 310, in recv
    opcode, data = self.recv_data()
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 327, in recv_data
    opcode, frame = self.recv_data_frame(control_frame)
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 354, in recv_data_frame
    self.send_close()
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 387, in send_close
    self.send(struct.pack('!H', status) + reason, ABNF.OPCODE_CLOSE)
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 250, in send
    return self.send_frame(frame)
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 275, in send_frame
    l = self._send(data)
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_core.py", line 445, in _send
    return send(self.sock, data)
  File "/home/remy/.local/lib/python3.6/site-packages/websocket/_socket.py", line 114, in send
    raise WebSocketConnectionClosedException("socket is already closed.")
websocket._exceptions.WebSocketConnectionClosedException: socket is already closed.

```